### PR TITLE
Removes the babypipeline datasets and its content

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,13 @@ import sys
 import logging
 
 from pipeline.init_datasets import initialize as run_init_datasets
+from pipeline.prune_datasets import prune_datasets as run_prune_datasets
 
 logging.basicConfig(level=logging.INFO)
 
 SUBCOMMANDS = {
     "init_datasets": run_init_datasets,
+    "prune_datasets": run_prune_datasets,
 }
 
 if __name__ == "__main__":

--- a/pipeline/prune_datasets.py
+++ b/pipeline/prune_datasets.py
@@ -1,0 +1,59 @@
+"""
+Initialize datasets where to store the baby_pipeline results
+1. Filter the datsets using labels, particularly the step:init_datasets (only created by baby_pipeline)
+2. Remove the datsets but keep the last two dates.
+"""
+from google.cloud import bigquery as bq
+
+import argparse
+import logging
+import re
+import time
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--dataset_prefix',
+                    help='Pattern in babypipeline datasets which has the date on it. Date Format: str.',
+                    default="pipe_ais_test_YYYYMMDD",
+                    required=False)
+required = parser.add_argument_group('Required named arguments')
+
+def get_pipe_ver():
+    with open('setup.py') as rf:
+        return re.search(r'version=\'(v[0-9.]*)\'', rf.read()).group(1)
+
+def prune_datasets(argv):
+    """
+    Prune the baby pipeline datasets where was stored the baby_pipeline results
+    """
+    options = parser.parse_args(argv)
+    start_time = time.time()
+
+    logging.info(f'Removal of baby-pipeline datasets version {get_pipe_ver()}')
+    logging.info('Running prune baby pipeline datasets with args %s', options)
+    client = bq.Client()
+    PATTERN_LEN = len(options.dataset_prefix)
+
+    get_datasets = client.list_datasets(filter='labels.step:init_datasets') # Make an API request.
+    if not get_datasets:
+        logging.info(f'Baby-pipeline datasets to remove not found.')
+        return 0
+    datasets = list(map(lambda x: x.dataset_id, get_datasets))
+
+    dataset_pattern_uniques = list(set(map(lambda x:x[:PATTERN_LEN], datasets)))
+    dataset_pattern_uniques.sort()
+    pattern_to_remove = dataset_pattern_uniques[:-2]
+
+    datasets_to_remove = list(filter(lambda x: x[:PATTERN_LEN] in pattern_to_remove, datasets))
+    for dataset_id in datasets_to_remove:
+        client.delete_dataset(
+            dataset_id, delete_contents=True, not_found_ok=True
+        ) # Make an API request.
+
+    ### ALL DONE
+    logging.info(f'Baby-pipeline datasets removed: {datasets_to_remove}')
+    logging.info(f'Execution time {(time.time()-start_time)/60} minutes')
+    return 0
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(prune_datasets(sys.argv[1:]))

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ from setuptools import setup
 
 setup(
     name="pipe-babypipeline",
-    version='v1.2.0',
+    version='v1.3.0',
     packages=find_packages(exclude=["test*.*", "tests"]),
 )


### PR DESCRIPTION
- Adds the `prune_datasets` functionality.
- The functionality removes the `baby-pipeline` datasets keeping the last two newest.

If we have the following:
```
pipe_ais_test_20230613_daily_internal
pipe_ais_test_20230613_daily_published
pipe_ais_test_20230626_daily_internal
pipe_ais_test_20230626_daily_published
pipe_ais_test_20230626_monthly_internal
pipe_ais_test_20230626_monthly_published
pipe_ais_test_20230707_daily_internal
pipe_ais_test_20230707_daily_published
pipe_ais_test_20230814_daily_internal
pipe_ais_test_20230814_daily_published
pipe_ais_test_20230814_monthly_internal
pipe_ais_test_20230814_monthly_published
pipe_ais_test_20231027_monthly_internal
pipe_ais_test_20231027_monthly_published
```

It will keep the last two newest:
```
pipe_ais_test_20230814_daily_internal
pipe_ais_test_20230814_daily_published
pipe_ais_test_20230814_monthly_internal
pipe_ais_test_20230814_monthly_published
pipe_ais_test_20231027_monthly_internal
pipe_ais_test_20231027_monthly_published
```
And will remove the rest.


Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1388